### PR TITLE
fix: calculate hash

### DIFF
--- a/src/__tests__/__snapshots__/pinoLoggerOptionsBuilder.spec.ts.snap
+++ b/src/__tests__/__snapshots__/pinoLoggerOptionsBuilder.spec.ts.snap
@@ -104,7 +104,28 @@ exports[`PinoLoggerOptionsBuilder must log error with extra undefined argument 1
 {
   "context": "some context",
   "env": "test",
-  "err": "some error",
+  "err": {
+    "message": "some error",
+    "stack": "Error: some error",
+    "type": "Error",
+  },
+  "errHash": "932f64f7",
+  "hostname": "host",
+  "level": "error",
+  "msg": "some error",
+  "msgTemplateHash": "7611b3bb",
+  "name": "name",
+  "pid": 123456,
+  "time": "2016-04-05T17:02:19.796Z",
+  "version": "version",
+}
+`;
+
+exports[`PinoLoggerOptionsBuilder must log custom error with extra undefined argument 1`] = `
+{
+  "context": "some custom context",
+  "env": "test",
+  "err": "some custom error",
   "hostname": "host",
   "level": "error",
   "msgTemplateHash": "3fb211a9",

--- a/src/__tests__/__snapshots__/pinoLoggerOptionsBuilder.spec.ts.snap
+++ b/src/__tests__/__snapshots__/pinoLoggerOptionsBuilder.spec.ts.snap
@@ -104,16 +104,10 @@ exports[`PinoLoggerOptionsBuilder must log error with extra undefined argument 1
 {
   "context": "some context",
   "env": "test",
-  "err": {
-    "message": "some error",
-    "stack": "Error: some error",
-    "type": "Error",
-  },
-  "errHash": "932f64f7",
+  "err": "some error",
   "hostname": "host",
   "level": "error",
-  "msg": "some error",
-  "msgTemplateHash": "7611b3bb",
+  "msgTemplateHash": "3fb211a9",
   "name": "name",
   "pid": 123456,
   "time": "2016-04-05T17:02:19.796Z",

--- a/src/__tests__/pinoLoggerOptionsBuilder.spec.ts
+++ b/src/__tests__/pinoLoggerOptionsBuilder.spec.ts
@@ -87,9 +87,6 @@ describe("PinoLoggerOptionsBuilder", () => {
   });
 
   it("must log error with extra undefined argument", () => {
-    const error = new Error("some error");
-    error.stack = "Error: some error";
-
     //only for nest logger in 9.3.0 and later
     //first param is always undefined if not use params in log.error()
     //if params in log.error() is set, then first extraArg mustn't be undefined
@@ -101,7 +98,7 @@ describe("PinoLoggerOptionsBuilder", () => {
 
     pino(builder.build()).error(
       {
-        err: error,
+        err: "some error",
         context: "some context",
       },
       ...extraArguments,

--- a/src/__tests__/pinoLoggerOptionsBuilder.spec.ts
+++ b/src/__tests__/pinoLoggerOptionsBuilder.spec.ts
@@ -87,6 +87,9 @@ describe("PinoLoggerOptionsBuilder", () => {
   });
 
   it("must log error with extra undefined argument", () => {
+    const error = new Error("some error");
+    error.stack = "Error: some error";
+
     //only for nest logger in 9.3.0 and later
     //first param is always undefined if not use params in log.error()
     //if params in log.error() is set, then first extraArg mustn't be undefined
@@ -98,8 +101,30 @@ describe("PinoLoggerOptionsBuilder", () => {
 
     pino(builder.build()).error(
       {
-        err: "some error",
+        err: error,
         context: "some context",
+      },
+      ...extraArguments,
+    );
+    stdout.stop();
+
+    expect(JSON.parse(stdout.output)).toMatchSnapshot();
+  });
+
+  it("must log custom error with extra undefined argument", () => {
+    //only for nest logger in 9.3.0 and later
+    //first param is always undefined if not use params in log.error()
+    //if params in log.error() is set, then first extraArg mustn't be undefined
+    const extraArguments = [undefined];
+
+    const builder = new PinoLoggerOptionsBuilder();
+
+    stdout.start();
+
+    pino(builder.build()).error(
+      {
+        err: "some custom error",
+        context: "some custom context",
       },
       ...extraArguments,
     );

--- a/src/providers/pinoLoggerOptionsBuilder.ts
+++ b/src/providers/pinoLoggerOptionsBuilder.ts
@@ -140,7 +140,7 @@ export class PinoLoggerOptionsBuilder {
           message.errHash = murmurhash(message.err.stack ?? "").toString(16);
         }
 
-        if (optionalParams.length > 0) {
+        if (optionalParams.length > 0 && optionalParams[0]) {
           message.msgTemplateHash = murmurhash(
             optionalParams[0] as string,
           ).toString(16);

--- a/src/providers/pinoLoggerOptionsBuilder.ts
+++ b/src/providers/pinoLoggerOptionsBuilder.ts
@@ -140,9 +140,9 @@ export class PinoLoggerOptionsBuilder {
           message.errHash = murmurhash(message.err.stack ?? "").toString(16);
         }
 
-        if (optionalParams.length > 0 && optionalParams[0]) {
+        if (optionalParams.length > 0) {
           message.msgTemplateHash = murmurhash(
-            optionalParams[0] as string,
+            String(optionalParams[0]),
           ).toString(16);
         }
 


### PR DESCRIPTION
Исправлена ошибка:

```
 /workspaces/node_modules/murmurhash/murmurhash.js:74
     remainder = key.length & 3; // key.length % 4
                     ^
 TypeError: Cannot read properties of undefined (reading 'length')
```

При логировании ошибки, из nest может приходить undefined в optionalParams[0], из-за чего падает logger при попытке создания msgTemplateHash.